### PR TITLE
Replace heuristic 2 with temp heuristic

### DIFF
--- a/src/forecaster/heuristic.py
+++ b/src/forecaster/heuristic.py
@@ -44,16 +44,18 @@ def apply_heuristics(internal_series: dict, enrolment: dict, low_bound: int, hig
                     internal_series[course]["capacity"] = math.floor(enrolment * math.pow(PROGRAM_GROWTH, (i+1)))
                     break
 
-    # Compute number of remaining seats, and unassigned courses
+    # Assign remaining courses via temporary heuristic
     for course in internal_series.keys():
-        if internal_series[course]["capacity"] != 0:
-            remaining_seats -= internal_series[course]["capacity"]
-        else:
-            unassigned_courses += 1
+        if int(internal_series[course]["capacity"]) <= 0:
+            course_code = ''.join(c for c in course if c.isdigit())
+            if course_code[0] >= '4': # fourth year or greater
+                internal_series[course]["capacity"] = 50
+            elif course_code.startswith('3'):
+                internal_series[course]["capacity"] = 60
+            elif course_code.startswith('2'):
+                internal_series[course]["capacity"] = 80
+            elif course_code.startswith('1'):
+                internal_series[course]["capacity"] = 100
+            else: # What else could it be? Who knows but we must guarantee an output
+                internal_series[course]["capacity"] = 80
 
-    # Assign remaining courses via Heuristic 2
-    if unassigned_courses > 0:
-        seats_per_course = math.floor(remaining_seats / unassigned_courses)
-        for course in internal_series.keys():
-            if internal_series[course]["capacity"] <= 0:
-                internal_series[course]["capacity"] = seats_per_course

--- a/test/test_heuristic.py
+++ b/test/test_heuristic.py
@@ -31,9 +31,9 @@ def test_apply_heuristics_no_data():
 
     low, high = compute_bounds(en)
     apply_heuristics(internal_series, en, low, high)
-    assert internal_series["CSC110-F"]["capacity"] == 2816
-    assert internal_series["CSC116-F"]["capacity"] == 2816
-    assert internal_series["SENG265-F"]["capacity"] == 2816
+    assert internal_series["CSC110-F"]["capacity"] == 100
+    assert internal_series["CSC116-F"]["capacity"] == 100
+    assert internal_series["SENG265-F"]["capacity"] == 80
 
 
 def test_apply_heuristics_some_data():
@@ -47,6 +47,6 @@ def test_apply_heuristics_some_data():
 
     low, high = compute_bounds(en)
     apply_heuristics(internal_series, en, low, high)
-    assert internal_series["CSC110-F"]["capacity"] == 4157
+    assert internal_series["CSC110-F"]["capacity"] == 100
     assert internal_series["CSC116-F"]["capacity"] == 134
-    assert internal_series["SENG265-F"]["capacity"] == 4157
+    assert internal_series["SENG265-F"]["capacity"] == 80


### PR DESCRIPTION
This PR adds a temporary heuristic which, in the case that a course has no historic enrolment data, will assign it a hardcoded capacity based on the year the course is offered.

1st year = 100 seats
2nd year = 80 seats
3rd year = 60 seats
4th year and up = 50 seats

If the course code somehow doesn't fall into any of the above categories we assign 80 seats.