### PR TITLE
Check for NoneType data field in first heuristic

### DIFF
--- a/src/forecaster/heuristic.py
+++ b/src/forecaster/heuristic.py
@@ -56,7 +56,7 @@ def apply_heuristics(internal_series: dict, enrolment: dict) -> None:
 
     # Assign capacities to courses which have a data point
     for course in internal_series.keys():
-        if internal_series[course]["capacity"] <= 0:
+        if internal_series[course]["capacity"] <= 0 and internal_series[course]["data"] is not None:
             logging.debug('%s Trying Heuristics with data' % (str(course).ljust(15, ' ')))
             for i, enrolment in enumerate(reversed(internal_series[course]["data"])):
                 if enrolment != 0:

--- a/test/test_heuristic.py
+++ b/test/test_heuristic.py
@@ -20,9 +20,9 @@ def test_apply_heuristics_all_data():
 
 
 def test_apply_heuristics_no_data():
-    internal_series = {"CSC110-F": {"data": [0], "approach": 0, "capacity": 0},
-                       "CSC116-F": {"data": [0], "approach": 1, "capacity": 0},
-                       "SENG265-F": {"data": [0], "approach": 0, "capacity": 0}}
+    internal_series = {"CSC110-F": {"data": None, "approach": 0, "capacity": 0},
+                       "CSC116-F": {"data": None, "approach": 1, "capacity": 0},
+                       "SENG265-F": {"data": None, "approach": 0, "capacity": 0}}
 
     with open("../data/real/programEnrollmentData.json", "r") as fb:
         en_json = json.load(fb)
@@ -35,9 +35,9 @@ def test_apply_heuristics_no_data():
 
 
 def test_apply_heuristics_some_data():
-    internal_series = {"CSC110-F": {"data": [0], "approach": 0, "capacity": 0},
+    internal_series = {"CSC110-F": {"data": None, "approach": 0, "capacity": 0},
                        "CSC116-F": {"data": [124], "approach": 1, "capacity": 0},
-                       "SENG265-F": {"data": [0], "approach": 0, "capacity": 0}}
+                       "SENG265-F": {"data": None, "approach": 0, "capacity": 0}}
 
     with open("../data/real/programEnrollmentData.json", "r") as fb:
         en_json = json.load(fb)


### PR DESCRIPTION
Heuristic module unit tests did not exercise the case that an internal series object would have a `None` data field. This hotfix checks for this before trying to access the data field. 